### PR TITLE
Update for results of the HCBBS [S7]

### DIFF
--- a/season7/markers.js
+++ b/season7/markers.js
@@ -21,68 +21,51 @@ var MAPCRAFTER_MARKERS = [
 		"markers": {
 			// ...in the world "world"
 			"world": [
-				//Done
-				{ "pos": [-1391, 610, 64], "title": "Bumbo Baggins' hobbit hole (Scar) (Originally Mumbo's)", "icon": "scar.png" },
-				{ "pos": [-1330, 555, 64], "title": "Scar's main base (Originally Mumbo's)", "icon": "scar.png" },
-				{ "pos": [-1685, 695, 64], "title": "The Big Dig (Mumbo) (Originally Scar's)", "icon": "scar.png" },
-				{ "pos": [-1363, 765, 64], "title": "Mumbo's Cursed Nether Portal (Originally Scar's)", "icon": "mumbo.png" },
-				{ "pos": [-1223, 761, 64], "title": "Mumbo's Magical village (Originally Scar's)", "icon": "mumbo.png" },
-
-				{ "pos": [210, -1310, 64], "title": "Three Fox Hole (Iskall) (Originally Beef's)", "icon": "iskall.png" },
-				{ "pos": [-817, -292, 64], "title": "Iskall's hacienda and village (Originally Beef's)", "icon": "iskall.png" },
-				{ "pos": [-719, 469, 64], "title": "Beef's starter base (Originally Iskall's)", "icon": "beef.png" },
-				{ "pos": [-1015, 575, 64], "title": "Beef's Omega Tree (of Doom) (Originally Iskall's)", "icon": "beef.png" },
-
-				{ "pos": [-293, -313, 64], "title": "Stress's sea-pyramid (Originally Impulse's)", "icon": "stress.png" },
-				{ "pos": [-383, -390, 64], "title": "Stress's starter village (Originally Impulse's)", "icon": "stress.png" },
-				{ "pos": [-927, 803, 64], "title": "Impulse's rainbow jungle (Originally Stress's)", "icon": "impulse.png" },
-
-				{ "pos": [615, 615, 64], "title": "Doc's Great Pyramid (Originally Cub's)", "icon": "doc.png" },
-				{ "pos": [530, 450, 65], "title": "Doc's Pyramid (Originally Cub's)", "icon": "doc.png" },
-				{ "pos": [1140, -837, 64], "title": "Cub's half-mansion (Originally Doc's)", "icon": "cub.png" },
-				{ "pos": [900, -530, 120], "title": "Cub's Testificate Tower (Originally Doc's)", "icon": "cub.png" },
-
-				{ "pos": [-200, -650, 64], "title": "The Cave of Contraptions (Grian) (Orginally Zedaph's)", "icon": "grian.png" },
-				{ "pos": [-255, -667, 64], "title": "The Oval of Life (Grian) (Orginally Zedaph's)", "icon": "grian.png" },
-				{ "pos": [-1192, 862, 64], "title": "Zedaph's hobbit hole (Orginally Grian's)", "icon": "zedaph.png" },
-				{ "pos": [-1199, 971, 64], "title": "Zedaph's mansion (Orginally Grian's)", "icon": "zedaph.png" },
-
-				{ "pos": [-1085, -92, 64], "title": "Cleo's construction site (Originally Keralis's)", "icon": "cleo.png" },
-				{ "pos": [1600, 600, 65], "title": "Keralis's zoo (Originally Cleo's)", "icon": "keralis.png" },
-
-				{ "pos": [-120, -400, 64], "title": "False's starter house (Originally Tango's)", "icon": "false.png" },
-				{ "pos": [30, -420, 64], "title": "False Towers (Originally Tango's)", "icon": "false.png" },
-				{ "pos": [417, -333, 64], "title": "Tango's base (Originally False's)", "icon": "tango.png" },
-
-				{ "pos": [4360, -4840, 64], "title": "JoeHills's base (Originally xBCrafted's)", "icon": "joe.png" },
-				{ "pos": [1075, -1000, 55], "title": "xBCrafted's ship (Originally Joe Hills's)", "icon": "xb.png" },
-				{ "pos": [1160, -1100, 65], "title": "xBCrafted's vineyard (Originally  Joe Hills's)", "icon": "xb.png" },
-				{ "pos": [900, -1060, 64], "title": "Joerassic Bark (xBCrafted) (Originally  Joe Hills's)", "icon": "xb.png" },
-
-				//Untouched
 				{ "pos": [1515, -938, 64], "title": "Bdubs' base", "icon": "bdubs.png" },
 				{ "pos": [1780, -900, 64], "title": "Bdubs' clifftop castle", "icon": "bdubs.png" },
 				{ "pos": [1140, -818, 64], "title": "Bdubs' half-mansion", "icon": "bdubs.png" },
-
+				{ "pos": [-719, 469, 64], "title": "Beef's starter base (Originally Iskall's)", "icon": "beef.png" },
+				{ "pos": [-1015, 575, 64], "title": "Beef's Omega Tree (of Doom) (Originally Iskall's)", "icon": "beef.png" },
+				{ "pos": [-1085, -92, 64], "title": "Cleo's construction site (Originally Keralis's)", "icon": "cleo.png" },
+				{ "pos": [1140, -837, 64], "title": "Cub's half-mansion (Originally Doc's)", "icon": "cub.png" },
+				{ "pos": [900, -530, 120], "title": "Cub's Testificate Tower (Originally Doc's)", "icon": "cub.png" },
+				{ "pos": [615, 615, 64], "title": "Doc's Great Pyramid (Originally Cub's)", "icon": "doc.png" },
+				{ "pos": [530, 450, 65], "title": "Doc's Pyramid (Originally Cub's)", "icon": "doc.png" },
 				{ "pos": [-1440, -435, 64], "title": "Etho's Monstrosity", "icon": "etho.png" },
-
+				{ "pos": [-120, -400, 64], "title": "False's starter house (Originally Tango's)", "icon": "false.png" },
+				{ "pos": [30, -420, 64], "title": "False Towers (Originally Tango's)", "icon": "false.png" },
+				{ "pos": [-200, -650, 64], "title": "The Cave of Contraptions (Grian) (Orginally Zedaph's)", "icon": "grian.png" },
+				{ "pos": [-255, -667, 64], "title": "The Oval of Life (Grian) (Orginally Zedaph's)", "icon": "grian.png" },
 				{ "pos": [1490, -250, 64], "title": "Hypno's boardwalk", "icon": "hypno.png" },
-				{ "pos": [875, -250, 64], "title": "Hypno's island", "icon": "hypno.png" },
-
+				{ "pos": [875, -250, 64], "title": "Hypno's island", "icon": "hypno.png" },	
 				{ "pos": [-583, -122, 64], "title": "Jevin's Megabase", "icon": "ijevin.png" },
 				{ "pos": [-622, -409, 64], "title": "Jevin's no longer floating house", "icon": "ijevin.png" },
-
+				{ "pos": [-927, 803, 64], "title": "Impulse's rainbow jungle (Originally Stress's)", "icon": "impulse.png" },
+				{ "pos": [210, -1310, 64], "title": "Three Fox Hole (Iskall) (Originally Beef's)", "icon": "iskall.png" },
+				{ "pos": [-817, -292, 64], "title": "Iskall's hacienda and village (Originally Beef's)", "icon": "iskall.png" },
+				{ "pos": [4360, -4840, 64], "title": "JoeHills's base (Originally xBCrafted's)", "icon": "joe.png" },
+				{ "pos": [1600, 600, 65], "title": "Keralis's zoo (Originally Cleo's)", "icon": "keralis.png" },
+				{ "pos": [-1363, 765, 64], "title": "Mumbo's Cursed Nether Portal (Originally Scar's)", "icon": "mumbo.png" },
+				{ "pos": [-1223, 761, 64], "title": "Mumbo's Magical village (Originally Scar's)", "icon": "mumbo.png" },
 				{ "pos": [-32, 520, 64], "title": "Dead Dog Gulch (Rendog)", "icon": "rendog.png" },
 				{ "pos": [531, 10, 64], "title": "Loser isle (Rendog)", "icon": "rendog.png" },
 				{ "pos": [-680, 988, 64], "title": "Tatooren (Rendog)", "icon": "rendog.png" },
 				{ "pos": [-747, 996, 64], "title": "The Emperor's Fortress", "icon": "rendog.png" },
 				{ "pos": [-718, 1098, 64], "title": "The Emperor's Talon", "icon": "rendog.png" },
-
+				{ "pos": [-1391, 610, 64], "title": "Bumbo Baggins' hobbit hole (Scar) (Originally Mumbo's)", "icon": "scar.png" },
+				{ "pos": [-1330, 555, 64], "title": "Scar's main base (Originally Mumbo's)", "icon": "scar.png" },
+				{ "pos": [-1685, 695, 64], "title": "The Big Dig (Mumbo) (Originally Scar's)", "icon": "scar.png" },
+				{ "pos": [-293, -313, 64], "title": "Stress's sea-pyramid (Originally Impulse's)", "icon": "stress.png" },
+				{ "pos": [-383, -390, 64], "title": "Stress's starter village (Originally Impulse's)", "icon": "stress.png" },
+				{ "pos": [417, -333, 64], "title": "Tango's base (Originally False's)", "icon": "tango.png" },
 				{ "pos": [64, -624, 64], "title": "TFC's tower", "icon": "tfc.png" },
-
 				{ "pos": [-841, -533, 64], "title": "Welsknight's starter house", "icon": "wels.png" },
-
+				{ "pos": [1075, -1000, 55], "title": "xBCrafted's ship (Originally Joe Hills's)", "icon": "xb.png" },
+				{ "pos": [1160, -1100, 65], "title": "xBCrafted's vineyard (Originally  Joe Hills's)", "icon": "xb.png" },
+				{ "pos": [900, -1060, 64], "title": "Joerassic Bark (xBCrafted) (Originally  Joe Hills's)", "icon": "xb.png" },
 				{ "pos": [-1400, -275, 64], "title": "Xisuma's area", "icon": "xisuma.png" },
+				{ "pos": [-1192, 862, 64], "title": "Zedaph's hobbit hole (Orginally Grian's)", "icon": "zedaph.png" },
+				{ "pos": [-1199, 971, 64], "title": "Zedaph's mansion (Orginally Grian's)", "icon": "zedaph.png" },
 			],
 		},
 	},

--- a/season7/markers.js
+++ b/season7/markers.js
@@ -21,66 +21,45 @@ var MAPCRAFTER_MARKERS = [
 		"markers": {
 			// ...in the world "world"
 			"world": [
-				/* TODO:
-				 * 
-				 * MumboJumbo <-> GoodTimesWithScar
-				 * Docm77 <-> Cubfan135
-				 * JoeHillsTSD <-> xBCrafted
-				 * FalseSymmetry <-> TangoTek
-				 * ZombieCleo <-> Keralis
-				 * VintageBeef <-> Iskall85
-				 * Grian <-> Zedaph
-				 * StressMonster101 <-> ImpulseSV
-				 */
-
-				{ "pos": [210, -1310, 64], "title": "Three Fox Hole (Beef)", "icon": "beef.png" },
-				{ "pos": [-817, -292, 64], "title": "Beef's hacienda and village", "icon": "beef.png" },
-
-				{ "pos": [1600, 600, 65], "title": "ZombieCleo's zoo", "icon": "cleo.png" },
-
-				{ "pos": [615, 615, 64], "title": "Cub's Great Pyramid", "icon": "cub.png" },
-				{ "pos": [530, 450, 65], "title": "Cub's Pyramid", "icon": "cub.png" },
-
-				{ "pos": [1140, -837, 64], "title": "Doc's half-mansion", "icon": "doc.png" },
-				{ "pos": [900, -530, 120], "title": "Doc's Testificate Tower", "icon": "doc.png" },
-
-				{ "pos": [417, -333, 64], "title": "False's base", "icon": "false.png" },
-
-				{ "pos": [-1192, 862, 64], "title": "Grian's hobbit hole", "icon": "grian.png" },
-				{ "pos": [-1199, 971, 64], "title": "Grian's mansion", "icon": "grian.png" },
-
-				{ "pos": [-293, -313, 64], "title": "Impulse's sea-pyramid", "icon": "impulse.png" },
-				{ "pos": [-383, -390, 64], "title": "Impulse's starter village", "icon": "impulse.png" },
-
-				{ "pos": [-719, 469, 64], "title": "Iskall's starter base", "icon": "iskall.png" },
-				{ "pos": [-1015, 575, 64], "title": "Iskall's Omega Tree (of doom)", "icon": "iskall.png" },
-
-				{ "pos": [1075, -1000, 55], "title": "Joe Hills's ship", "icon": "joe.png" },
-				{ "pos": [1160, -1100, 65], "title": "Joe Hills's vineyard", "icon": "joe.png" },
-				{ "pos": [900, -1060, 64], "title": "Joerassic Bark", "icon": "joe.png" },
-
-				{ "pos": [-1085, -92, 64], "title": "Keralis' construction site", "icon": "keralis.png" },
-
-				{ "pos": [-1391, 610, 64], "title": "Bumbo Baggins' hobbit hole (Mumbo)", "icon": "mumbo.png" },
-				{ "pos": [-1330, 555, 64], "title": "Mumbo's main base", "icon": "mumbo.png" },
-
-				{ "pos": [-1685, 695, 64], "title": "The Big Dig (Scar)", "icon": "scar.png" },
-				{ "pos": [-1363, 765, 64], "title": "Scar's Cursed Nether Portal", "icon": "scar.png" },
-				{ "pos": [-1223, 761, 64], "title": "Scar's Magical village", "icon": "scar.png" },
-
-				{ "pos": [-927, 803, 64], "title": "Stressmonster's rainbow jungle", "icon": "stress.png" },
-
-				{ "pos": [-120, -400, 64], "title": "Tango's starter house", "icon": "tango.png" },
-				{ "pos": [30, -420, 64], "title": "Toon Towers (Tango)", "icon": "tango.png" },
-
-				{ "pos": [4360, -4840, 64], "title": "xBCrafted's base", "icon": "xb.png" },
-
-				{ "pos": [-200, -650, 64], "title": "The Cave of Contraptions (Zedaph)", "icon": "zedaph.png" },
-				{ "pos": [-255, -667, 64], "title": "The Oval of Life (Zedaph)", "icon": "zedaph.png" },
-
-				//------------------------------------------------------------------------------------------------
 				//Done
+				{ "pos": [-1391, 610, 64], "title": "Bumbo Baggins' hobbit hole (Scar) (Originally Mumbo's)", "icon": "scar.png" },
+				{ "pos": [-1330, 555, 64], "title": "Scar's main base (Originally Mumbo's)", "icon": "scar.png" },
+				{ "pos": [-1685, 695, 64], "title": "The Big Dig (Mumbo) (Originally Scar's)", "icon": "scar.png" },
+				{ "pos": [-1363, 765, 64], "title": "Mumbo's Cursed Nether Portal (Originally Scar's)", "icon": "mumbo.png" },
+				{ "pos": [-1223, 761, 64], "title": "Mumbo's Magical village (Originally Scar's)", "icon": "mumbo.png" },
 
+				{ "pos": [210, -1310, 64], "title": "Three Fox Hole (Iskall) (Originally Beef's)", "icon": "iskall.png" },
+				{ "pos": [-817, -292, 64], "title": "Iskall's hacienda and village (Originally Beef's)", "icon": "iskall.png" },
+				{ "pos": [-719, 469, 64], "title": "Beef's starter base (Originally Iskall's)", "icon": "beef.png" },
+				{ "pos": [-1015, 575, 64], "title": "Beef's Omega Tree (of Doom) (Originally Iskall's)", "icon": "beef.png" },
+
+				{ "pos": [-293, -313, 64], "title": "Stress's sea-pyramid (Originally Impulse's)", "icon": "stress.png" },
+				{ "pos": [-383, -390, 64], "title": "Stress's starter village (Originally Impulse's)", "icon": "stress.png" },
+				{ "pos": [-927, 803, 64], "title": "Impulse's rainbow jungle (Originally Stress's)", "icon": "impulse.png" },
+
+				{ "pos": [615, 615, 64], "title": "Doc's Great Pyramid (Originally Cub's)", "icon": "doc.png" },
+				{ "pos": [530, 450, 65], "title": "Doc's Pyramid (Originally Cub's)", "icon": "doc.png" },
+				{ "pos": [1140, -837, 64], "title": "Cub's half-mansion (Originally Doc's)", "icon": "cub.png" },
+				{ "pos": [900, -530, 120], "title": "Cub's Testificate Tower (Originally Doc's)", "icon": "cub.png" },
+
+				{ "pos": [-200, -650, 64], "title": "The Cave of Contraptions (Grian) (Orginally Zedaph's)", "icon": "grian.png" },
+				{ "pos": [-255, -667, 64], "title": "The Oval of Life (Grian) (Orginally Zedaph's)", "icon": "grian.png" },
+				{ "pos": [-1192, 862, 64], "title": "Zedaph's hobbit hole (Orginally Grian's)", "icon": "zedaph.png" },
+				{ "pos": [-1199, 971, 64], "title": "Zedaph's mansion (Orginally Grian's)", "icon": "zedaph.png" },
+
+				{ "pos": [-1085, -92, 64], "title": "Cleo's construction site (Originally Keralis's)", "icon": "cleo.png" },
+				{ "pos": [1600, 600, 65], "title": "Keralis's zoo (Originally Cleo's)", "icon": "keralis.png" },
+
+				{ "pos": [-120, -400, 64], "title": "False's starter house (Originally Tango's)", "icon": "false.png" },
+				{ "pos": [30, -420, 64], "title": "False Towers (Originally Tango's)", "icon": "false.png" },
+				{ "pos": [417, -333, 64], "title": "Tango's base (Originally False's)", "icon": "tango.png" },
+
+				{ "pos": [4360, -4840, 64], "title": "JoeHills's base (Originally xBCrafted's)", "icon": "joe.png" },
+				{ "pos": [1075, -1000, 55], "title": "xBCrafted's ship (Originally Joe Hills's)", "icon": "xb.png" },
+				{ "pos": [1160, -1100, 65], "title": "xBCrafted's vineyard (Originally  Joe Hills's)", "icon": "xb.png" },
+				{ "pos": [900, -1060, 64], "title": "Joerassic Bark (xBCrafted) (Originally  Joe Hills's)", "icon": "xb.png" },
+
+				//Untouched
 				{ "pos": [1515, -938, 64], "title": "Bdubs' base", "icon": "bdubs.png" },
 				{ "pos": [1780, -900, 64], "title": "Bdubs' clifftop castle", "icon": "bdubs.png" },
 				{ "pos": [1140, -818, 64], "title": "Bdubs' half-mansion", "icon": "bdubs.png" },

--- a/season7/markers.js
+++ b/season7/markers.js
@@ -21,51 +21,89 @@ var MAPCRAFTER_MARKERS = [
 		"markers": {
 			// ...in the world "world"
 			"world": [
-				{ "pos": [1515, -938, 64], "title": "Bdubs' base", "icon": "bdubs.png" },
-				{ "pos": [1780, -900, 64], "title": "Bdubs' clifftop castle", "icon": "bdubs.png" },
-				{ "pos": [1140, -818, 64], "title": "Bdubs' half-mansion", "icon": "bdubs.png" },
+				/* TODO:
+				 * 
+				 * MumboJumbo <-> GoodTimesWithScar
+				 * Docm77 <-> Cubfan135
+				 * JoeHillsTSD <-> xBCrafted
+				 * FalseSymmetry <-> TangoTek
+				 * ZombieCleo <-> Keralis
+				 * VintageBeef <-> Iskall85
+				 * Grian <-> Zedaph
+				 * StressMonster101 <-> ImpulseSV
+				 */
+
 				{ "pos": [210, -1310, 64], "title": "Three Fox Hole (Beef)", "icon": "beef.png" },
 				{ "pos": [-817, -292, 64], "title": "Beef's hacienda and village", "icon": "beef.png" },
+
 				{ "pos": [1600, 600, 65], "title": "ZombieCleo's zoo", "icon": "cleo.png" },
+
 				{ "pos": [615, 615, 64], "title": "Cub's Great Pyramid", "icon": "cub.png" },
 				{ "pos": [530, 450, 65], "title": "Cub's Pyramid", "icon": "cub.png" },
+
 				{ "pos": [1140, -837, 64], "title": "Doc's half-mansion", "icon": "doc.png" },
 				{ "pos": [900, -530, 120], "title": "Doc's Testificate Tower", "icon": "doc.png" },
-				{ "pos": [-1440, -435, 64], "title": "Etho's Monstrosity", "icon": "etho.png" },
+
 				{ "pos": [417, -333, 64], "title": "False's base", "icon": "false.png" },
+
 				{ "pos": [-1192, 862, 64], "title": "Grian's hobbit hole", "icon": "grian.png" },
 				{ "pos": [-1199, 971, 64], "title": "Grian's mansion", "icon": "grian.png" },
-				{ "pos": [1490, -250, 64], "title": "Hypno's boardwalk", "icon": "hypno.png" },
-				{ "pos": [875, -250, 64], "title": "Hypno's island", "icon": "hypno.png" },
-				{ "pos": [-583, -122, 64], "title": "Jevin's Megabase", "icon": "ijevin.png" },
-				{ "pos": [-622, -409, 64], "title": "Jevin's no longer floating house", "icon": "ijevin.png" },
+
 				{ "pos": [-293, -313, 64], "title": "Impulse's sea-pyramid", "icon": "impulse.png" },
 				{ "pos": [-383, -390, 64], "title": "Impulse's starter village", "icon": "impulse.png" },
+
 				{ "pos": [-719, 469, 64], "title": "Iskall's starter base", "icon": "iskall.png" },
 				{ "pos": [-1015, 575, 64], "title": "Iskall's Omega Tree (of doom)", "icon": "iskall.png" },
+
 				{ "pos": [1075, -1000, 55], "title": "Joe Hills's ship", "icon": "joe.png" },
 				{ "pos": [1160, -1100, 65], "title": "Joe Hills's vineyard", "icon": "joe.png" },
 				{ "pos": [900, -1060, 64], "title": "Joerassic Bark", "icon": "joe.png" },
+
 				{ "pos": [-1085, -92, 64], "title": "Keralis' construction site", "icon": "keralis.png" },
+
 				{ "pos": [-1391, 610, 64], "title": "Bumbo Baggins' hobbit hole (Mumbo)", "icon": "mumbo.png" },
 				{ "pos": [-1330, 555, 64], "title": "Mumbo's main base", "icon": "mumbo.png" },
+
+				{ "pos": [-1685, 695, 64], "title": "The Big Dig (Scar)", "icon": "scar.png" },
+				{ "pos": [-1363, 765, 64], "title": "Scar's Cursed Nether Portal", "icon": "scar.png" },
+				{ "pos": [-1223, 761, 64], "title": "Scar's Magical village", "icon": "scar.png" },
+
+				{ "pos": [-927, 803, 64], "title": "Stressmonster's rainbow jungle", "icon": "stress.png" },
+
+				{ "pos": [-120, -400, 64], "title": "Tango's starter house", "icon": "tango.png" },
+				{ "pos": [30, -420, 64], "title": "Toon Towers (Tango)", "icon": "tango.png" },
+
+				{ "pos": [4360, -4840, 64], "title": "xBCrafted's base", "icon": "xb.png" },
+
+				{ "pos": [-200, -650, 64], "title": "The Cave of Contraptions (Zedaph)", "icon": "zedaph.png" },
+				{ "pos": [-255, -667, 64], "title": "The Oval of Life (Zedaph)", "icon": "zedaph.png" },
+
+				//------------------------------------------------------------------------------------------------
+				//Done
+
+				{ "pos": [1515, -938, 64], "title": "Bdubs' base", "icon": "bdubs.png" },
+				{ "pos": [1780, -900, 64], "title": "Bdubs' clifftop castle", "icon": "bdubs.png" },
+				{ "pos": [1140, -818, 64], "title": "Bdubs' half-mansion", "icon": "bdubs.png" },
+
+				{ "pos": [-1440, -435, 64], "title": "Etho's Monstrosity", "icon": "etho.png" },
+
+				{ "pos": [1490, -250, 64], "title": "Hypno's boardwalk", "icon": "hypno.png" },
+				{ "pos": [875, -250, 64], "title": "Hypno's island", "icon": "hypno.png" },
+
+				{ "pos": [-583, -122, 64], "title": "Jevin's Megabase", "icon": "ijevin.png" },
+				{ "pos": [-622, -409, 64], "title": "Jevin's no longer floating house", "icon": "ijevin.png" },
+
 				{ "pos": [-32, 520, 64], "title": "Dead Dog Gulch (Rendog)", "icon": "rendog.png" },
 				{ "pos": [531, 10, 64], "title": "Loser isle (Rendog)", "icon": "rendog.png" },
 				{ "pos": [-680, 988, 64], "title": "Tatooren (Rendog)", "icon": "rendog.png" },
 				{ "pos": [-747, 996, 64], "title": "The Emperor's Fortress", "icon": "rendog.png" },
 				{ "pos": [-718, 1098, 64], "title": "The Emperor's Talon", "icon": "rendog.png" },
-				{ "pos": [-1685, 695, 64], "title": "The Big Dig (Scar)", "icon": "scar.png" },
-				{ "pos": [-1363, 765, 64], "title": "Scar's Cursed Nether Portal", "icon": "scar.png" },
-				{ "pos": [-1223, 761, 64], "title": "Scar's Magical village", "icon": "scar.png" },
-				{ "pos": [-927, 803, 64], "title": "Stressmonster's rainbow jungle", "icon": "stress.png" },
-				{ "pos": [-120, -400, 64], "title": "Tango's starter house", "icon": "tango.png" },
-				{ "pos": [30, -420, 64], "title": "Toon Towers (Tango)", "icon": "tango.png" },
+
 				{ "pos": [64, -624, 64], "title": "TFC's tower", "icon": "tfc.png" },
+
 				{ "pos": [-841, -533, 64], "title": "Welsknight's starter house", "icon": "wels.png" },
-				{ "pos": [4360, -4840, 64], "title": "xBCrafted's base", "icon": "xb.png" },
+
 				{ "pos": [-1400, -275, 64], "title": "Xisuma's area", "icon": "xisuma.png" },
-				{ "pos": [-200, -650, 64], "title": "The Cave of Contraptions (Zedaph)", "icon": "zedaph.png" },
-				{ "pos": [-255, -667, 64], "title": "The Oval of Life (Zedaph)", "icon": "zedaph.png" },
 			],
 		},
 	},


### PR DESCRIPTION
The base markers for all swapped Hermits have been transferred to their new owners in the format `B's base (originally A's)`. This resolved #53. More discussion can be found in the linked issue.