### PR TITLE
Added Scar's and Pearl's mountains to the map

### DIFF
--- a/season8/markers.js
+++ b/season8/markers.js
@@ -53,8 +53,10 @@ var MAPCRAFTER_MARKERS = [
 				{ "pos": [850, -860, 64], "title": "Mumbo's Sustainable Utopia", "icon": "mumbo.png" },
 				
 				{ "pos": [850, -622, 64], "title": "Pearl's starter base", "icon": "pearl.png" },
+				{ "pos": [1030, -760, 64], "title": "Pearl's mountains", "icon": "pearl.png" },
 				
 				{ "pos": [900, -630, 64], "title": "Scar's starter base", "icon": "scar.png" },
+				{ "pos": [990, -815, 64], "title": "Scar's snow-capped peaks", "icon": "scar.png" },
 				
 				{ "pos": [835, 101, 55], "title": "Stress' ravine", "icon": "stress.png" },
 				


### PR DESCRIPTION
Added Scar's snow-capped peaks that are above Grian's Diagon Alley inspired base and Pearl's mountain so all of the botem-gigabase megabases are on the map